### PR TITLE
fix(util): close each layer reader before opening the next

### DIFF
--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -172,70 +172,90 @@ func GetFSFromLayers(root string, layers []v1.Layer, opts ...FSOpt) ([]string, e
 			logrus.Tracef("Extracting layer %d", i)
 		}
 
-		r, err := l.Uncompressed()
+		files, err := extractLayer(root, i, l, cfg)
 		if err != nil {
 			return nil, err
 		}
-		defer r.Close()
+		extractedFiles = append(extractedFiles, files...)
+	}
+	return extractedFiles, nil
+}
 
-		tr := tar.NewReader(r)
-		for {
-			hdr, err := tr.Next()
-			if errors.Is(err, io.EOF) {
-				break
-			}
+// extractLayer extracts a single layer into root.
+//
+// The layer reader is opened and closed within this function, deliberately:
+// go-containerregistry v0.21.6 and later gate concurrent blob fetches behind a
+// pullLimiter with a small fixed number of slots (defaultJobs = 4), and a slot
+// is only returned when the reader is closed. Holding every layer's reader open
+// until the whole image had been unpacked leaked a slot per layer, so from the
+// fifth layer onwards Uncompressed() blocked forever on limiter.acquire with no
+// deadline. Keeping the reader scoped to one layer returns each slot before the
+// next layer is fetched.
+func extractLayer(root string, i int, l v1.Layer, cfg *FSConfig) ([]string, error) {
+	r, err := l.Uncompressed()
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
 
-			if err != nil {
-				return nil, errors.Wrap(err, fmt.Sprintf("error reading tar %d", i))
-			}
-
-			cleanedName := filepath.Clean(hdr.Name)
-			if cleanedName == ".." || strings.HasPrefix(cleanedName, "../") {
-				return nil, fmt.Errorf("tar entry %q is not allowed: references parent directory", hdr.Name)
-			}
-			path := filepath.Join(root, cleanedName)
-			base := filepath.Base(path)
-
-			if strings.HasPrefix(base, archive.WhiteoutPrefix) {
-				// SecureJoin resolves symlinks and ensures the result stays
-				// within root, which is needed because this code path calls
-				// os.RemoveAll.
-				securePath, err := securejoin.SecureJoin(root, cleanedName)
-				if err != nil {
-					return nil, fmt.Errorf("resolving whiteout path for %q: %w", hdr.Name, err)
-				}
-				dir := filepath.Dir(securePath)
-				logrus.Tracef("Whiting out %s", securePath)
-
-				name := strings.TrimPrefix(base, archive.WhiteoutPrefix)
-				path := filepath.Join(dir, name)
-
-				if CheckCleanedPathAgainstIgnoreList(path) {
-					logrus.Tracef("Not deleting %s, as it's ignored", path)
-					continue
-				}
-				if childDirInIgnoreList(path) {
-					logrus.Tracef("Not deleting %s, as it contains a ignored path", path)
-					continue
-				}
-
-				if err := os.RemoveAll(path); err != nil {
-					return nil, errors.Wrapf(err, "removing whiteout %s", hdr.Name)
-				}
-
-				if !cfg.includeWhiteout {
-					logrus.Trace("Not including whiteout files")
-					continue
-				}
-
-			}
-
-			if err := cfg.extractFunc(root, hdr, cleanedName, tr); err != nil {
-				return nil, err
-			}
-
-			extractedFiles = append(extractedFiles, filepath.Join(root, cleanedName))
+	extractedFiles := []string{}
+	tr := tar.NewReader(r)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
 		}
+
+		if err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("error reading tar %d", i))
+		}
+
+		cleanedName := filepath.Clean(hdr.Name)
+		if cleanedName == ".." || strings.HasPrefix(cleanedName, "../") {
+			return nil, fmt.Errorf("tar entry %q is not allowed: references parent directory", hdr.Name)
+		}
+		path := filepath.Join(root, cleanedName)
+		base := filepath.Base(path)
+
+		if strings.HasPrefix(base, archive.WhiteoutPrefix) {
+			// SecureJoin resolves symlinks and ensures the result stays
+			// within root, which is needed because this code path calls
+			// os.RemoveAll.
+			securePath, err := securejoin.SecureJoin(root, cleanedName)
+			if err != nil {
+				return nil, fmt.Errorf("resolving whiteout path for %q: %w", hdr.Name, err)
+			}
+			dir := filepath.Dir(securePath)
+			logrus.Tracef("Whiting out %s", securePath)
+
+			name := strings.TrimPrefix(base, archive.WhiteoutPrefix)
+			path := filepath.Join(dir, name)
+
+			if CheckCleanedPathAgainstIgnoreList(path) {
+				logrus.Tracef("Not deleting %s, as it's ignored", path)
+				continue
+			}
+			if childDirInIgnoreList(path) {
+				logrus.Tracef("Not deleting %s, as it contains a ignored path", path)
+				continue
+			}
+
+			if err := os.RemoveAll(path); err != nil {
+				return nil, errors.Wrapf(err, "removing whiteout %s", hdr.Name)
+			}
+
+			if !cfg.includeWhiteout {
+				logrus.Trace("Not including whiteout files")
+				continue
+			}
+
+		}
+
+		if err := cfg.extractFunc(root, hdr, cleanedName, tr); err != nil {
+			return nil, err
+		}
+
+		extractedFiles = append(extractedFiles, filepath.Join(root, cleanedName))
 	}
 	return extractedFiles, nil
 }

--- a/pkg/util/fs_util_limiter_test.go
+++ b/pkg/util/fs_util_limiter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Chainguard, Inc.
+Copyright 2026 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/util/fs_util_limiter_test.go
+++ b/pkg/util/fs_util_limiter_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 Chainguard, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+	"io"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+// ggcrDefaultJobs mirrors go-containerregistry's remote.defaultJobs, the size
+// of the pullLimiter slot pool.
+const ggcrDefaultJobs = 4
+
+// limiterLayer models the pullLimiter that go-containerregistry v0.21.6 and
+// later put in front of remote blob fetches: Uncompressed() takes a slot from a
+// fixed-size pool and blocks, with no deadline, once the pool is exhausted. The
+// slot is only returned when the reader is closed.
+//
+// GetFSFromLayers used to defer every layer's Close() until the whole image had
+// been unpacked, so the slots leaked and the fifth layer blocked forever. This
+// fake reproduces that deadlock without needing a registry.
+type limiterLayer struct {
+	v1.Layer // only MediaType and Uncompressed are exercised
+	tokens   chan struct{}
+	body     []byte
+}
+
+func (l *limiterLayer) MediaType() (types.MediaType, error) { return types.OCILayer, nil }
+
+func (l *limiterLayer) Uncompressed() (io.ReadCloser, error) {
+	l.tokens <- struct{}{}
+	return &limiterReadCloser{Reader: bytes.NewReader(l.body), tokens: l.tokens}, nil
+}
+
+type limiterReadCloser struct {
+	io.Reader
+	tokens chan struct{}
+	once   sync.Once
+}
+
+func (r *limiterReadCloser) Close() error {
+	r.once.Do(func() { <-r.tokens })
+	return nil
+}
+
+func Test_GetFSFromLayers_releases_reader_before_next_layer(t *testing.T) {
+	resetMountInfoFile := provideEmptyMountinfoFile()
+	defer resetMountInfoFile()
+
+	root := t.TempDir()
+
+	// More layers than the limiter has slots, so a leak is guaranteed to block.
+	const numLayers = ggcrDefaultJobs * 3
+	tokens := make(chan struct{}, ggcrDefaultJobs)
+
+	layers := make([]v1.Layer, 0, numLayers)
+	expectedFiles := make([]string, 0, numLayers)
+	for i := 0; i < numLayers; i++ {
+		name := fmt.Sprintf("file-%d", i)
+
+		buf := new(bytes.Buffer)
+		tw := tar.NewWriter(buf)
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     name,
+			Typeflag: tar.TypeReg,
+			Mode:     0o644,
+		}); err != nil {
+			t.Fatalf("writing tar header: %s", err)
+		}
+		if err := tw.Close(); err != nil {
+			t.Fatalf("closing tar writer: %s", err)
+		}
+
+		layers = append(layers, &limiterLayer{tokens: tokens, body: buf.Bytes()})
+		expectedFiles = append(expectedFiles, filepath.Join(root, name))
+	}
+
+	opts := []FSOpt{ExtractFunc(func(string, *tar.Header, string, io.Reader) error { return nil })}
+
+	type result struct {
+		files []string
+		err   error
+	}
+	done := make(chan result, 1)
+	go func() {
+		files, err := GetFSFromLayers(root, layers, opts...)
+		done <- result{files, err}
+	}()
+
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("GetFSFromLayers returned an error: %s", got.err)
+		}
+		if len(got.files) != len(expectedFiles) {
+			t.Fatalf("expected %d extracted files, got %d", len(expectedFiles), len(got.files))
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("GetFSFromLayers deadlocked: each layer's reader must be closed before the next layer is opened, or the go-containerregistry pullLimiter runs out of slots")
+	}
+
+	if len(tokens) != 0 {
+		t.Errorf("expected all %d limiter slots to be released, %d still held", ggcrDefaultJobs, len(tokens))
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the executor hang during "Unpacking rootfs" reported against `kaniko-fips:1.25.18-dev` (OS-2944, DEL2-4337, ZD#11323, ZD#11340). The root cause is in kaniko, not in a dependency, and no further dependency bump will fix it.

## The bug

`GetFSFromLayers` (`pkg/util/fs_util.go`) opens each layer's reader inside its loop but defers `r.Close()` to the end of the function, so no reader is closed until the entire image has been unpacked:

```go
for i, l := range layers {
    r, err := l.Uncompressed()
    if err != nil {
        return nil, err
    }
    defer r.Close()   // <- runs only when GetFSFromLayers returns
    ...
}
```

go-containerregistry **v0.21.6** introduced a `pullLimiter` in front of remote blob fetches (`pkg/v1/remote/limiter.go`). It has a fixed pool of slots (`remote.defaultJobs = 4`) and a slot is only returned when the reader is closed:

```go
func (l *pullLimiter) acquire(ctx context.Context) (func(), error) {
	select {
	case l.tokens <- struct{}{}:
		return func() { <-l.tokens }, nil
	case <-ctx.Done():
		return nil, ctx.Err()
	}
}
```

Holding every reader open leaks one slot per layer, so from the fifth layer onwards `Uncompressed()` blocks forever on that channel send with no deadline. The executor prints `Unpacking rootfs...`, produces no further output, never errors, and has to be killed externally. The reported goroutine dump matches exactly:

```
go-containerregistry@v0.21.9/pkg/v1/remote/limiter.go:37   pullLimiter.acquire
chainguard-dev/kaniko/pkg/util/fs_util.go:175              GetFSFromLayers
```

Two things worth flagging for anyone triaging this from the fork alone:

- **`go.mod` here still declares `go-containerregistry v0.21.5`, which has no limiter at all.** The version actually compiled into the published images is set downstream at build time, which is why the v1.25.17 to v1.25.18 dependency diff shows nothing relevant.
- **Pinning to v0.21.9 does not fix it.** `limiter.go` is byte-identical between v0.21.8 and v0.21.9 (sha256 `395dd0d0d584…` for both). The only change in that file since v0.21.7 is the `Read` error path added in v0.21.8, which releases the slot via `sync.Once` on a read error. That does not help a reader that completes normally and is left open.

## The fix

Move the per-layer body into a new `extractLayer` helper, so `defer r.Close()` is scoped to a single layer and the slot is returned before the next layer is fetched. Apart from the reader scoping this is a pure move: the extraction logic, the whiteout handling, the ignore-list checks and the SecureJoin path are all unchanged. No API change and no change to `GetFSFromLayers`' signature or behaviour.

## Scope assessment

Within EmeritOSS best-effort policy: small, contained, no API change, no refactor beyond extracting the loop body. This is a regression that breaks previously-working functionality rather than a feature or a general bug fix, same shape as the MinIO `ListenBucketNotification` fix (chainguard-forks/minio#37) and the symlink-extraction fix here (#440).

## Compatibility (ABI / API)

No exported symbol changes. `extractLayer` is unexported. No struct, interface or signature changes. Behaviour is identical except that layer readers are now closed promptly, which is strictly a fix to resource handling.

## Testing performed

All run locally against a Go 1.26 toolchain (`golang:1.26`, `GOFLAGS=-mod=vendor`).

- **Full unit suite:** `go test ./pkg/... ./cmd/...` passes, no failures.
- **Vet and format:** `go vet ./pkg/util/` clean, `gofmt -l pkg/util/` clean.
- **Existing coverage:** all four pre-existing `Test_GetFSFromLayers*` tests (whiteouts enabled/disabled, ignorelist, base case) still pass.
- **New regression test** (`pkg/util/fs_util_limiter_test.go`): a fake layer models the limiter, taking a slot from a four-slot pool on `Uncompressed()` and returning it only on `Close()`. Twelve layers are unpacked, three times the pool size, and the test asserts both that the call completes within 30s and that all four slots are released afterwards.
- **Negative control:** the same test against the unpatched `fs_util.go` hangs and fails on the 30s timeout with `GetFSFromLayers deadlocked: each layer's reader must be closed before the next layer is opened...`. Against the patched code it passes in 0.00s.
- Remaining: the CI matrix on this PR, including the integration suite, is the authoritative coverage.

## Note for validation

Reporters found this does **not** reproduce with docker.io bases (`python:3.12`, `alpine`), which build cleanly. Please validate against a base pulled from a redirecting private registry rather than docker.io, or the result will look clean regardless.

Separately, one report describes a deadlock against a base said to be single-layer. A slot leak alone requires more layers than slots, so if that holds up there may be a second consumer of limiter slots on the private-registry path. This PR fixes the leak that the goroutine dump points at; it may not be the whole story for that specific case.

Refs: OS-2944, DEL2-4337, ZD#11323, ZD#11340