### PR TITLE
test(integration): move the issue-1039 fixture off end-of-life UBI 7

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_1039
+++ b/integration/dockerfiles/Dockerfile_test_issue_1039
@@ -1,10 +1,19 @@
-FROM registry.access.redhat.com/ubi7/ubi:7.7-214
+# Regression test for https://github.com/GoogleContainerTools/kaniko/issues/1039:
+# a yum-based image whose install layer produces whiteout entries must build,
+# and must remain usable as a base for a further build.
+#
+# Originally based on ubi7/ubi:7.7-214. RHEL 7 is end of life and its repos no
+# longer resolve (subscription-manager now requires python-requests, which is
+# unavailable), so `yum update` fails at the reference `docker build` before
+# kaniko is even invoked. Moved to UBI 9, which keeps the yum/whiteout coverage
+# the test exists for.
+FROM registry.access.redhat.com/ubi9/ubi:9.8
 
 # Install GCC, GCC-C++ and make libraries for build environment
 # Then clean caches
 RUN yum --disableplugin=subscription-manager update -y \
     && yum --disableplugin=subscription-manager install -y \
-        gcc-4.8.5-39.el7 \
-        gcc-c++-4.8.5-39.el7 \
-        make-3.82-24.el7 \
+        gcc \
+        gcc-c++ \
+        make \
     && yum --disableplugin=subscription-manager clean all


### PR DESCRIPTION
## Summary

`integration/dockerfiles/Dockerfile_test_issue_1039` is based on `ubi7/ubi:7.7-214`. RHEL 7 is end of life and its repos no longer resolve, so the fixture fails to build at all. This is currently red on **every** PR, which leaves the repo effectively unmergeable.

## The problem

The fixture's `RUN` step does `yum update -y`, which pulls `subscription-manager 1.24.54`, which requires `python-requests`. That package is no longer available in the `ubi-7` repo:

```
Error: Package: subscription-manager-1.24.54-1.el7_9.x86_64 (ubi-7)
           Requires: python-requests
The command '/bin/sh -c yum --disableplugin=subscription-manager update -y ...' returned a non-zero code: 1
```

This surfaces as `--- FAIL: TestRun/test_Dockerfile_test_issue_1039` in both `integration-test-run` and `integration-test-layers`.

**It is not a kaniko defect.** The failure is in the harness's reference `docker build`, before the kaniko executor is invoked:

```
integration_test.go:658: Error building image: Failed to build image
localhost:5000/docker-dockerfile_test_issue_1039 with docker command
"[docker build --no-cache -t ... -f dockerfiles/Dockerfile_test_issue_1039 ...]": exit status 1
```

Failing on unrelated branches since at least 2026-08-24: runs `32922816594` (dependabot `gomod-` branch) and `32682917426`.

## The fix

Move the fixture to `registry.access.redhat.com/ubi9/ubi:9.8` and drop the pinned el7 RPM versions (`gcc-4.8.5-39.el7` and friends), which do not exist outside RHEL 7. Added a comment recording what the fixture is for and why it moved.

**The tag pin was never the problem.** `yum update` reaches the live repos regardless of which image digest is pinned, so a fixture shaped like this will always rot once its distro goes end of life. Worth knowing when UBI 9 eventually follows. The sibling `ubi8/ubi:8.2` fixture will hit the same wall in time.

## Preserving the test's value

Issue 1039 was a whiteout-handling regression: `removing whiteout .wh.dev: unlinkat //dev/pts/ptmx: operation not permitted`. A replacement that merely goes green would be worse than useless, so I checked the coverage survives:

- The new fixture builds cleanly under `docker build --no-cache`.
- Building it with the kaniko executor still produces **whiteout entries** in the resulting layer (5 `.wh.` entries, e.g. `usr/lib64/.wh.libattr.so.1.1.2501`), so the whiteout path in `GetFSFromLayers` is still exercised.

In fairness, the specific `.wh.dev` shape from the original report is not reproduced verbatim, and I do not think it can be forced reliably. What the test still covers is the general case: a yum-based image whose install layer generates whiteouts builds correctly through kaniko.

## Testing performed

- `docker build --no-cache` of the new fixture: succeeds.
- `kaniko executor --no-push --tar-path` of the new fixture: succeeds, output tar inspected and confirmed to contain whiteout entries.
- Verified `ubi9/ubi:9.8` exists and is a current tag.
- Remaining: the integration matrix on this PR, which is the point of the change.

## Note

Separate from, and not dependent on, #477. That PR is approved but blocked by exactly these two red jobs; this one should unblock it.